### PR TITLE
feat(generation): RAG vs 无检索生成质量对比 — closes #9

### DIFF
--- a/scripts/evalGenerationComparison.py
+++ b/scripts/evalGenerationComparison.py
@@ -243,6 +243,13 @@ def run_norag_baseline(
 
 def build_comparison_report(groups: list[dict[str, Any]]) -> dict[str, Any]:
     """组合各实验组结果，生成对比报告 JSON。"""
+    if not groups:
+        return {
+            "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
+            "total_groups": 0,
+            "groups": [],
+            "comparison": {},
+        }
     best_term = max(groups, key=lambda g: g["generation_metrics"]["term_hit_rate"])
     best_src = max(
         groups, key=lambda g: g["generation_metrics"]["source_citation_rate"]
@@ -344,6 +351,12 @@ def main() -> None:
     print("🔬 Math-RAG 生成质量对比实验")
     print("=" * 60)
 
+    # 文件存在性检查
+    for label, path in [("RAG结果", args.rag_results), ("查询集", args.queries)]:
+        if not os.path.isfile(path):
+            print(f"[错误] {label}文件不存在: {path}")
+            sys.exit(1)
+
     # 加载数据
     rag_results = _load_rag_results(args.rag_results)
     gold_map = _load_queries(args.queries)
@@ -361,7 +374,7 @@ def main() -> None:
     # 2. 无检索基线
     run_norag = not args.skip_norag and args.norag_limit > 0
     if run_norag:
-        all_queries = list(gold_map.values())
+        all_queries = sorted(gold_map.values(), key=lambda q: q["query"])
         norag_queries = all_queries[: args.norag_limit]
         norag_group = run_norag_baseline(norag_queries, gold_map)
         groups.append(norag_group)

--- a/scripts/generateReport.py
+++ b/scripts/generateReport.py
@@ -504,8 +504,8 @@ def generate_report(
         try:
             comparison_data = _load_json(comparison_path)
             print(f"[数据] 生成对比: {len(comparison_data.get('groups', []))} 组")
-        except Exception:
-            pass
+        except Exception as exc:
+            print(f"[警告] 生成对比结果加载失败: {comparison_path} ({exc})")
 
     os.makedirs(figures_dir, exist_ok=True)
     dir_name = os.path.dirname(output_path)


### PR DESCRIPTION
## 变更说明

完成 issue #9 [Plan-6] 评测体系的最后子任务：**对比实验（RAG vs 无检索）**。

### 新增文件

- `scripts/evalGenerationComparison.py`：一键评估生成质量并运行无检索基线推理

### 功能

**evalGenerationComparison.py**：
1. 读取 `outputs/rag_results.jsonl`，对 105 条 RAG 结果计算生成指标
2. 可选：运行 Qwen 无检索推理（`--norag-limit N`），作为对照组
3. 输出 `outputs/reports/comparison_results.json`，包含两组完整指标

**generateReport.py 更新**：
- 新增 `_generation_comparison_table()` 函数
- 新增 `--comparison` CLI 参数（默认读取 comparison_results.json）
- 在 final_report.md 中插入第 6 章【生成质量对比（RAG vs 无检索）】

### 实验结果

| 实验组 | 检索策略 | Recall@5 | 术语命中率 | 来源引用率 | 回答有效率 | 延迟(ms) |
|--------|----------|----------|------------|------------|------------|----------|
| rag-bm25plus | BM25+（Qwen2.5-Math-7B） | 52.31% | 42.47% | 0% | 100% | 16052 |
| baseline-norag（10条采样） | 无 | N/A | 60% | 0% | 100% | 21179 |

Closes #9

## Summary by Sourcery

添加一个评估流水线和报告，用于比较基于 RAG 的生成与无检索基线，并将该比较结果集成到最终评估报告中。

新功能：
- 引入 `evalGenerationComparison.py`，用于计算现有 RAG 输出及可选的“无检索 Qwen 基线”的生成质量指标，并保存合并后的对比 JSON 报告。
- 在最终报告中新增一个生成质量对比的 Markdown 部分（RAG vs 无检索），包括渲染后的表格和关键发现总结。

增强改进：
- 扩展 `generateReport.py` 以加载可选的对比指标，调整章节编号，并新增 `--comparison` CLI 参数用于指定对比结果路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an evaluation pipeline and reporting for comparing RAG-based generation with a no-retrieval baseline, and integrate the comparison into the final evaluation report.

New Features:
- Introduce evalGenerationComparison.py to compute generation-quality metrics for existing RAG outputs and an optional no-retrieval Qwen baseline, and to save a consolidated comparison JSON report.
- Add a Markdown generation-quality comparison section (RAG vs no retrieval) to the final report, including a rendered table and key findings summary.

Enhancements:
- Extend generateReport.py to load optional comparison metrics, adjust section numbering, and expose a new --comparison CLI parameter for specifying the comparison results path.

</details>