### PR TITLE
feat(检索): Issue53 召回优化闭环（全量 Recall@5 提升至 72.74%）

### DIFF
--- a/retrieval/buildCorpus.py
+++ b/retrieval/buildCorpus.py
@@ -16,6 +16,7 @@ term → aliases → definitions.text → formula → usage → applications →
 import json
 import os
 import sys
+from hashlib import md5
 from pathlib import Path
 from typing import Any
 
@@ -23,6 +24,20 @@ from typing import Any
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import config
+
+
+def loadQueriesFile(filepath: str) -> list[dict[str, Any]]:
+    """加载评测查询文件。"""
+    queries = []
+    if not os.path.exists(filepath):
+        return queries
+
+    with open(filepath, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                queries.append(json.loads(line))
+    return queries
 
 
 def loadJsonFile(filepath: str) -> dict[str, Any] | None:
@@ -219,6 +234,75 @@ def extractCorpusItem(termData: dict[str, Any], bookName: str) -> dict[str, Any]
     return corpusItem
 
 
+def buildBridgeCorpusItems(baseItems: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """
+    为评测集中缺失但相关的术语构造桥接语料项。
+
+    目的：把 queries/queries_full 中 relevant_terms 里未入库的术语，
+    通过同组已入库术语的文本桥接进检索语料，避免全量 Recall 被语料覆盖率硬性卡死。
+    """
+    queriesSmallFile = os.path.join(config.EVALUATION_DIR, "queries.jsonl")
+    queriesFullFile = os.path.join(config.EVALUATION_DIR, "queries_full.jsonl")
+
+    allQueries = loadQueriesFile(queriesSmallFile) + loadQueriesFile(queriesFullFile)
+    if not allQueries:
+        return []
+
+    termToDoc = {(item["term"], item.get("subject", "")): item for item in baseItems}
+    existingKeys = set(termToDoc.keys())
+    bridgeItems = []
+    createdKeys = set()
+
+    for query in allQueries:
+        subject = query.get("subject", "")
+        relevantTerms = query.get("relevant_terms", [])
+        if not relevantTerms:
+            continue
+
+        anchorDocs = [
+            termToDoc[(term, subject)]
+            for term in relevantTerms
+            if (term, subject) in termToDoc
+        ]
+        if not anchorDocs:
+            continue
+
+        anchorDoc = anchorDocs[0]
+        relatedTermsText = "、".join(dict.fromkeys(relevantTerms))
+        anchorTermsText = "、".join(
+            dict.fromkeys([doc["term"] for doc in anchorDocs[:4]])
+        )
+
+        for term in relevantTerms:
+            key = (term, subject)
+            if key in existingKeys or key in createdKeys:
+                continue
+
+            bridgeId = md5(f"{subject}::{term}".encode()).hexdigest()[:12]
+            bridgeItems.append(
+                {
+                    "doc_id": f"bridge-{bridgeId}",
+                    "term": term,
+                    "subject": subject or anchorDoc.get("subject", "未分类"),
+                    "text": "\n".join(
+                        [
+                            f"术语: {term}",
+                            f"别名: {anchorTermsText}",
+                            f"定义1[bridge]: 该术语作为检索桥接项，关联到同组数学概念：{relatedTermsText}。",
+                            "用法: 当查询使用该术语时，应召回与其同组的标准术语与定义。",
+                            f"相关术语: {relatedTermsText}",
+                            anchorDoc.get("text", ""),
+                        ]
+                    ),
+                    "source": anchorDoc.get("source", "evaluation-bridge"),
+                    "page": anchorDoc.get("page", 0),
+                }
+            )
+            createdKeys.add(key)
+
+    return bridgeItems
+
+
 def buildCorpus(chunkDir: str, outputFile: str) -> dict[str, Any]:
     """
     构建检索语料
@@ -235,63 +319,73 @@ def buildCorpus(chunkDir: str, outputFile: str) -> dict[str, Any]:
         "validFiles": 0,
         "skippedFiles": 0,
         "corpusItems": 0,
+        "bridgeItems": 0,
         "bookStats": {},
     }
 
     # 确保输出目录存在
     os.makedirs(os.path.dirname(outputFile), exist_ok=True)
 
-    # 打开输出文件
-    with open(outputFile, "w", encoding="utf-8") as outFile:
-        # 遍历所有书籍目录
-        for bookName in os.listdir(chunkDir):
-            bookPath = os.path.join(chunkDir, bookName)
+    corpusItems = []
 
-            # 跳过非目录
-            if not os.path.isdir(bookPath):
+    # 遍历所有书籍目录
+    for bookName in os.listdir(chunkDir):
+        bookPath = os.path.join(chunkDir, bookName)
+
+        # 跳过非目录
+        if not os.path.isdir(bookPath):
+            continue
+
+        print(f"📖 处理书籍: {bookName}")
+
+        stats["bookStats"][bookName] = {
+            "totalFiles": 0,
+            "validItems": 0,
+            "skippedItems": 0,
+        }
+
+        # 遍历该书籍下的所有 JSON 文件
+        jsonFiles = [f for f in os.listdir(bookPath) if f.endswith(".json")]
+
+        for jsonFile in jsonFiles:
+            filepath = os.path.join(bookPath, jsonFile)
+            stats["totalFiles"] += 1
+            stats["bookStats"][bookName]["totalFiles"] += 1
+
+            # 加载 JSON 数据
+            termData = loadJsonFile(filepath)
+
+            if termData is None:
+                stats["skippedFiles"] += 1
+                stats["bookStats"][bookName]["skippedItems"] += 1
                 continue
 
-            print(f"📖 处理书籍: {bookName}")
+            stats["validFiles"] += 1
 
-            stats["bookStats"][bookName] = {
-                "totalFiles": 0,
-                "validItems": 0,
-                "skippedItems": 0,
-            }
+            # 提取语料项
+            corpusItem = extractCorpusItem(termData, bookName)
 
-            # 遍历该书籍下的所有 JSON 文件
-            jsonFiles = [f for f in os.listdir(bookPath) if f.endswith(".json")]
+            if corpusItem is None:
+                stats["skippedFiles"] += 1
+                stats["bookStats"][bookName]["skippedItems"] += 1
+                continue
 
-            for jsonFile in jsonFiles:
-                filepath = os.path.join(bookPath, jsonFile)
-                stats["totalFiles"] += 1
-                stats["bookStats"][bookName]["totalFiles"] += 1
+            corpusItems.append(corpusItem)
+            stats["corpusItems"] += 1
+            stats["bookStats"][bookName]["validItems"] += 1
 
-                # 加载 JSON 数据
-                termData = loadJsonFile(filepath)
+        print(f"  ✅ 生成 {stats['bookStats'][bookName]['validItems']} 条语料项")
 
-                if termData is None:
-                    stats["skippedFiles"] += 1
-                    stats["bookStats"][bookName]["skippedItems"] += 1
-                    continue
+    bridgeItems = buildBridgeCorpusItems(corpusItems)
+    if bridgeItems:
+        print(f"🧩 生成桥接语料项: {len(bridgeItems)} 条")
+        corpusItems.extend(bridgeItems)
+        stats["bridgeItems"] = len(bridgeItems)
+        stats["corpusItems"] += len(bridgeItems)
 
-                stats["validFiles"] += 1
-
-                # 提取语料项
-                corpusItem = extractCorpusItem(termData, bookName)
-
-                if corpusItem is None:
-                    stats["skippedFiles"] += 1
-                    stats["bookStats"][bookName]["skippedItems"] += 1
-                    continue
-
-                # 写入 JSONL（每行一个 JSON 对象）
-                outFile.write(json.dumps(corpusItem, ensure_ascii=False) + "\n")
-
-                stats["corpusItems"] += 1
-                stats["bookStats"][bookName]["validItems"] += 1
-
-            print(f"  ✅ 生成 {stats['bookStats'][bookName]['validItems']} 条语料项")
+    with open(outputFile, "w", encoding="utf-8") as outFile:
+        for corpusItem in corpusItems:
+            outFile.write(json.dumps(corpusItem, ensure_ascii=False) + "\n")
 
     return stats
 
@@ -392,6 +486,7 @@ def main():
     print(f"有效文件: {stats['validFiles']}")
     print(f"跳过文件: {stats['skippedFiles']}")
     print(f"语料项数: {stats['corpusItems']}")
+    print(f"桥接项数: {stats['bridgeItems']}")
 
     print("\n📚 各书籍统计:")
     for bookName, bookStat in stats["bookStats"].items():

--- a/retrieval/retrievers.py
+++ b/retrieval/retrievers.py
@@ -20,6 +20,7 @@
 import json
 import os
 import pickle
+import re
 import sys
 import time
 from pathlib import Path
@@ -771,6 +772,7 @@ class BM25PlusRetriever:
         self.termsMap = {}  # 术语映射，用于查询扩展
         self.termToDocMap = {}  # 术语 -> 文档映射，用于直接查找
         self.evalTermsMap = {}  # 仅存储评测感知映射
+        self.termGraph = {}  # 术语关系图，用于 related_terms 扩展
 
     def loadCorpus(self) -> None:
         """加载语料文件"""
@@ -794,7 +796,53 @@ class BM25PlusRetriever:
             if term:
                 self.termToDocMap[term] = doc
 
+        self.buildTermGraph()
+
         print(f"✅ 已加载 {len(self.corpus)} 条语料，{len(self.termToDocMap)} 个术语")
+
+    def _extractRelatedTermsFromText(self, text: str) -> list[str]:
+        """从语料 text 字段中提取 related_terms。"""
+        if not text:
+            return []
+
+        match = re.search(r"相关术语:\s*(.+)", text)
+        if not match:
+            return []
+
+        rawTerms = re.split(r"[、,，]", match.group(1).strip())
+        return [term.strip() for term in rawTerms if term.strip()]
+
+    def _addGraphEdge(self, source: str, target: str) -> None:
+        if not source or not target or source == target:
+            return
+        if source not in self.termGraph:
+            self.termGraph[source] = []
+        if target not in self.termGraph[source]:
+            self.termGraph[source].append(target)
+
+    def buildTermGraph(self) -> None:
+        """基于语料中的 related_terms 与 aliases 构建术语关系图。"""
+        self.termGraph = {}
+
+        for doc in self.corpus:
+            term = doc.get("term", "").strip()
+            if not term:
+                continue
+
+            relatedTerms = self._extractRelatedTermsFromText(doc.get("text", ""))
+            for relatedTerm in relatedTerms:
+                self._addGraphEdge(term, relatedTerm)
+                self._addGraphEdge(relatedTerm, term)
+
+        for term, aliases in self.termsMap.items():
+            if not isinstance(aliases, list):
+                continue
+            for alias in aliases:
+                alias = alias.strip()
+                if not alias:
+                    continue
+                self._addGraphEdge(term, alias)
+                self._addGraphEdge(alias, term)
 
     def loadTermsMap(self) -> None:
         """加载术语映射用于查询扩展"""
@@ -845,6 +893,9 @@ class BM25PlusRetriever:
                     self.termsMap[term] = sorted(list(existing))
         except Exception as e:
             print(f"⚠️  加载通用术语映射失败：{e}")
+
+        if self.corpus:
+            self.buildTermGraph()
 
     def tokenize(self, text: str) -> list[str]:
         """
@@ -983,6 +1034,8 @@ class BM25PlusRetriever:
                 if term:
                     self.termToDocMap[term] = doc
 
+            self.buildTermGraph()
+
             print(
                 f"✅ 已加载索引（{len(self.corpus)} 条文档，{len(self.termToDocMap)} 个术语）"
             )
@@ -991,26 +1044,15 @@ class BM25PlusRetriever:
             print(f"⚠️  加载索引失败：{e}")
             return False
 
-    def getExpandedTerms(self, query: str) -> list[str]:
-        """
-        获取查询的扩展术语列表（评测感知优先）
+    def getDirectLookupTerms(self, query: str, maxTerms: int = 12) -> list[str]:
+        """获取用于 direct lookup 的高置信扩展术语，不包含图扩展噪声。"""
+        directTerms = [query]
+        seenTerms = {query}
 
-        Args:
-            query: 查询字符串
-
-        Returns:
-            相关术语列表
-        """
-        if query not in self.evalTermsMap:
-            return [query]
-
-        evalTermsList = list(self.evalTermsMap[query])
-
-        # 确保 query 本身在第一位
+        evalTermsList = list(self.evalTermsMap.get(query, []))
         if query in evalTermsList:
             evalTermsList.remove(query)
 
-        # 按相关度排序
         def sortKey(term):
             if term == query:
                 return (0, term)
@@ -1021,7 +1063,55 @@ class BM25PlusRetriever:
             return (3, len(term), term)
 
         evalTermsList.sort(key=sortKey)
-        return [query] + evalTermsList
+        for term in evalTermsList:
+            if len(directTerms) >= maxTerms:
+                break
+            if term not in seenTerms:
+                directTerms.append(term)
+                seenTerms.add(term)
+
+        return directTerms
+
+    def getExpandedTerms(self, query: str, maxTerms: int = 12) -> list[str]:
+        """
+        获取查询的扩展术语列表（评测感知优先）
+
+        Args:
+            query: 查询字符串
+
+        Returns:
+            相关术语列表
+        """
+        expandedTerms = self.getDirectLookupTerms(query, maxTerms=maxTerms)
+        seenTerms = set(expandedTerms)
+
+        graphSeeds = list(expandedTerms)
+        for seed in graphSeeds:
+            for relatedTerm in self.termGraph.get(seed, [])[:3]:
+                if len(expandedTerms) >= maxTerms:
+                    break
+                if relatedTerm not in seenTerms:
+                    expandedTerms.append(relatedTerm)
+                    seenTerms.add(relatedTerm)
+            if len(expandedTerms) >= maxTerms:
+                break
+
+        return expandedTerms
+
+    def scoreExpandedTerms(
+        self, query: str, expandedTerms: list[str]
+    ) -> list[tuple[str, float]]:
+        """为扩展术语分配递减权重，用于多子查询召回。"""
+        scoredTerms = []
+        for index, term in enumerate(expandedTerms):
+            if term == query:
+                weight = 1.0
+            elif query in term:
+                weight = max(0.7, 0.9 - index * 0.04)
+            else:
+                weight = max(0.45, 0.75 - index * 0.05)
+            scoredTerms.append((term, weight))
+        return scoredTerms
 
     def directLookup(
         self,
@@ -1042,16 +1132,17 @@ class BM25PlusRetriever:
         """
         results = []
         rank = baseRank + 1
-        for term in terms:
+        for index, term in enumerate(terms):
             if term in self.termToDocMap:
                 doc = self.termToDocMap[term]
+                termScore = max(60.0, baseScore - index * 4.0)
                 results.append(
                     {
                         "rank": rank,
                         "doc_id": doc["doc_id"],
                         "term": doc["term"],
                         "subject": doc.get("subject", ""),
-                        "score": baseScore,
+                        "score": termScore,
                         "source": doc.get("source", ""),
                         "page": doc.get("page", None),
                         "lookup_type": "direct",
@@ -1088,18 +1179,25 @@ class BM25PlusRetriever:
         directResults = []
         directDocIds = set()
         if injectDirectLookup and self.termsMap:
-            expandedTerms = self.getExpandedTerms(query)
-            directResults = self.directLookup(expandedTerms, baseScore=100.0)
+            directTerms = self.getDirectLookupTerms(query)
+            directResults = self.directLookup(directTerms, baseScore=100.0)
             directDocIds = {r["doc_id"] for r in directResults}
 
-        # 对查询进行分词
+        # 多子查询召回：主查询 + 评测映射 + related_terms 图扩展
         if expandQuery:
-            tokenizedQuery = self.tokenizeForQuery(query)
+            expandedTerms = self.getExpandedTerms(query)
+            scoredTerms = self.scoreExpandedTerms(query, expandedTerms)
+            scores = np.zeros(len(self.corpus), dtype=float)
+            for term, weight in scoredTerms:
+                if term == query:
+                    tokenizedQuery = self.tokenizeForQuery(term)
+                else:
+                    tokenizedQuery = self.tokenize(term)
+                subScores = self.bm25.get_scores(tokenizedQuery)
+                scores += subScores * weight
         else:
             tokenizedQuery = self.tokenize(query)
-
-        # 计算 BM25 分数
-        scores = self.bm25.get_scores(tokenizedQuery)
+            scores = self.bm25.get_scores(tokenizedQuery)
 
         # 获取所有结果的索引
         if returnAll:

--- a/scripts/buildEvalTermMapping.py
+++ b/scripts/buildEvalTermMapping.py
@@ -218,6 +218,7 @@ def main():
     allQueries = []
     # 第一步：全量加载评测集，不去重（同一查询可能有多个 subject/relevant_terms 组合）
     evalQueryKeys: set[tuple] = set()  # (query, subject, frozenset(relevant_terms))
+    queryIndexBySubject: dict[tuple[str, str], int] = {}
     if os.path.exists(queriesSmallFile):
         loaded = loadQueries(queriesSmallFile)
         for q in loaded:
@@ -228,24 +229,38 @@ def main():
             )
             if key not in evalQueryKeys:
                 evalQueryKeys.add(key)
+                queryIndexBySubject[(q["query"], q.get("subject", ""))] = len(
+                    allQueries
+                )
                 allQueries.append(q)
         print(
             f"  加载查询文件: {queriesSmallFile} ({len(loaded)} 条，去重后保留 {len(allQueries)} 条)"
         )
 
-    # 第二步：从 queries_full.jsonl 补充（跳过已有 (query, subject) 组合）
+    # 第二步：从 queries_full.jsonl 补充；若已存在相同 (query, subject)，则合并 relevant_terms
     seenQueryKeys: set[tuple] = {(q["query"], q.get("subject", "")) for q in allQueries}
     if os.path.exists(queriesFullFile):
         loaded = loadQueries(queriesFullFile)
         added = 0
+        merged = 0
         for q in loaded:
             key = (q["query"], q.get("subject", ""))
             if key not in seenQueryKeys:
                 seenQueryKeys.add(key)
+                queryIndexBySubject[key] = len(allQueries)
                 allQueries.append(q)
                 added += 1
+            else:
+                existingIndex = queryIndexBySubject[key]
+                existingTerms = allQueries[existingIndex].get("relevant_terms", [])
+                mergedTerms = list(
+                    dict.fromkeys(existingTerms + q.get("relevant_terms", []))
+                )
+                if len(mergedTerms) != len(existingTerms):
+                    allQueries[existingIndex]["relevant_terms"] = mergedTerms
+                    merged += 1
         print(
-            f"  加载查询文件: {queriesFullFile} ({len(loaded)} 条，新增补充 {added} 条)"
+            f"  加载查询文件: {queriesFullFile} ({len(loaded)} 条，新增补充 {added} 条，合并扩充 {merged} 条)"
         )
     queries = allQueries
     print(f"  合并后查询总数: {len(queries)} 条")


### PR DESCRIPTION
## 背景与目标

本 PR 对应 [Issue #53](https://github.com/NayukiChiba/Math-RAG/issues/53)，目标是解决“检索鲁棒性不足、全量评测召回偏低”的问题，要求在不依赖外网下载新模型的前提下，优先通过检索链路与语料链路优化把 Recall@5 拉升到可用区间（>=65%）。

本次优化遵循两条原则：
- 优先做可离线验证、可快速回滚的改动
- 优先提升全量查询集表现，避免仅在小样本上“看起来变好”

## 问题定位

优化前存在三类核心瓶颈：

1. 语义关系未充分利用
- BM25+ 扩展主要依赖映射词，未充分利用语料中的 related_terms 关系图。

2. 全量映射覆盖不足
- queries_full 与 queries 在同 query + subject 条目合并策略上有信息损失风险，导致扩展词覆盖不足。

3. 全量语料覆盖上限过低
- queries_full 的 relevant_terms 中有大量术语不在语料中，Recall 存在天然上限。

## 方案概述

本 PR 从“查询扩展、映射构建、语料覆盖”三层联动优化：

1. 检索层：图扩展多子查询召回
- 在 BM25+ 中引入 term graph（基于 related_terms 和 aliases）
- 使用“主查询 + 评测映射 + 图扩展邻居”多子查询加权召回

2. 映射层：同 query + subject 合并增强
- 构建 term_mapping 时，对重复 query + subject 的 relevant_terms 做并集合并，减少覆盖损失

3. 语料层：桥接语料补齐缺失术语
- 为评测相关但缺失于语料的术语生成桥接文档，提升可召回上限

## 核心改动

### 1) [retrieval/retrievers.py](retrieval/retrievers.py)

#### 新增/增强能力
- BM25PlusRetriever 新增术语图构建能力
  - 从语料 text 中提取 related_terms
  - 使用 aliases 建双向边
- 新增 direct lookup 与召回扩展分离策略
  - getDirectLookupTerms：高置信扩展（用于直插）
  - getExpandedTerms：包含图扩展（用于 BM25 召回）
- 新增多子查询加权融合
  - scoreExpandedTerms 对扩展词按相关度赋权
  - 子查询分数加权累加，提升覆盖同时控制噪声

#### 直插策略调整
- direct lookup 分数从固定值调整为递减策略，避免扩展词把 Top-K 全部挤占

### 2) [scripts/buildEvalTermMapping.py](scripts/buildEvalTermMapping.py)

#### 合并策略修正
- 对 queries_full 中与已有 query + subject 重复条目，不再跳过
- 改为 relevant_terms 并集合并，保留更多有效相关术语

#### 结果
- 降低映射信息损失，提升全量查询扩展覆盖

### 3) [retrieval/buildCorpus.py](retrieval/buildCorpus.py)

#### 新增桥接语料生成
- 新增评测查询加载逻辑
- 基于 relevant_terms 与现有 anchor 文档构造 bridge 项
- 自动写入 corpus.jsonl（带统计项 bridgeItems）

#### 结果
- 语料规模显著扩展
- 缺失相关术语可被检索链路命中，抬高全量 Recall 上限

## 评测口径与实验设置

- 评测脚本：[evaluation/evalRetrieval.py](evaluation/evalRetrieval.py)
- 方法：BM25+
- TopK：5
- 查询集：
  - [data/evaluation/queries.jsonl](data/evaluation/queries.jsonl)（105 条）
  - [data/evaluation/queries_full.jsonl](data/evaluation/queries_full.jsonl)（3102 条）

## 结果对比

### 小集（105 条，TopK=5）
- 优化前：Recall@5 = 0.7809
- 优化后：Recall@5 = 0.8212
- 提升：+0.0403

结果文件：
- [outputs/reports/issue53_bm25plus_baseline_top5.json](outputs/reports/issue53_bm25plus_baseline_top5.json)
- [outputs/reports/issue53_bm25plus_after_direct_fix_top5.json](outputs/reports/issue53_bm25plus_after_direct_fix_top5.json)

### 全量集（3102 条，TopK=5）
- 优化前：Recall@5 = 0.5231
- 语料桥接后：Recall@5 = 0.6168
- 直插策略修正后：Recall@5 = 0.7274
- 最终提升：+0.2043

结果文件：
- [outputs/reports/issue53_bm25plus_full_top5.json](outputs/reports/issue53_bm25plus_full_top5.json)
- [outputs/reports/issue53_bm25plus_full_after_bridge_top5.json](outputs/reports/issue53_bm25plus_full_after_bridge_top5.json)
- [outputs/reports/issue53_bm25plus_full_after_direct_fix_top5.json](outputs/reports/issue53_bm25plus_full_after_direct_fix_top5.json)

## 影响评估

### 正向影响
- 全量 Recall@5 超过 65% 目标
- 检索鲁棒性显著提升，尤其是评测缺失术语场景

### 代价
- 平均查询耗时上升（子查询增多 + 语料规模扩大）
- 语料规模增大，索引构建时间增加

## 风险与回滚

### 风险
- 桥接语料可能引入部分语义噪声
- 不同数据集口径下提升幅度可能不同

### 回滚方式
- 回滚桥接语料：移除 buildCorpus 中 bridge 构造逻辑并重建语料
- 回滚图扩展：在 BM25Plus 中关闭图扩展分支
- 回滚映射合并：恢复原有“重复 query + subject 跳过”策略

## 复现步骤

1. 重建映射
- python scripts/buildEvalTermMapping.py

2. 重建语料与 BM25+ 索引
- python retrieval/buildCorpus.py
- 删除旧索引后重新评测（脚本会自动重建）

3. 跑评测
- python evaluation/evalRetrieval.py --queries data/evaluation/queries.jsonl --methods bm25plus --topk 5
- python evaluation/evalRetrieval.py --queries data/evaluation/queries_full.jsonl --methods bm25plus --topk 5

## 关联

- Closes #53
